### PR TITLE
Added push button debounce functionality

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,12 @@
-See http://www.mathertel.de/License.aspx
-
 Software License Agreement (BSD License)
 
-Copyright (c) 2005-2014 by Matthias Hertel,  http://www.mathertel.de/
+
+* Copyright (c) 2020 by Felix Hauser
+
+* Copyright (c) 2005-2014 by Matthias Hertel,  http://www.mathertel.de/ - Original RotaryEncoder library - See http://www.mathertel.de/License.aspx
+
+* Copyright (c) 2013 by Thomas Ouellet Fredericks, Eric Lowry, Jim Schimpf and Tom Harkaway - https://github.com/thomasfredericks - Original Bounce library 
+
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A library for the Arduino environment for using a rotary encoder as an input.
 
 Here you can find an Arduino compatible library for using rotary encoders.
 
-I was searching a library for using a rotary encoder in my latest project and found a lot of information on this topic but none of the existing libraries did immediately match my expectations so I finally built my own. 
+I was searching a library for using a rotary encoder in my latest project and found a lot of information on this topic but none of the existing libraries did immediately match my expectations so I finally built my own.
 
 It supports the type of rotary encoder that has a phase change on both input signals when rotating one `notch`.
 
@@ -13,4 +13,9 @@ the coding and might be able to adjust it to your needs if you like:
 
 <http://www.mathertel.de/Arduino/RotaryEncoderLibrary.aspx>
 
-There are various aspects when writing a library for rotary encoders and you can also find a lot of the sources I analyzed at the bottom of this article. 
+There are various aspects when writing a library for rotary encoders and you can also find a lot of the sources I analysed at the bottom of this article.
+
+
+## updates
+
+* 26.01.2020 Added debounce functionality for the encoder's push button. Based on the Bounce library by Thomas Fredericks' Bounce library: https://playground.arduino.cc/Code/Bounce/

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
-# BounceRotaryEncoder library
+# RotaryEncoder library
 
-This is a fork of the RotaryEncoder library by @mathertel which includes the debouncing functionallity for the push button.
-The debounce functionallity is based on the original Bounce library by Thomas Frederick.
+A library for the Arduino environment for using a rotary encoder as an input.
 
-* Original RotaryEncoder library: https://github.com/mathertel/RotaryEncoder
-* Original Bounce library: https://playground.arduino.cc/Code/Bounce/
+Here you can find an Arduino compatible library for using rotary encoders.
 
-# Why?
+I was searching a library for using a rotary encoder in my latest project and found a lot of information on this topic but none of the existing libraries did immediately match my expectations so I finally built my own.
 
-If you are working on a project with multiple push buttons, it makes sense to use any other library to manage the debouncing of said buttons. However if you are working on a small project in which you only need the push button of the encoder, you can use this library to manage that.
+It supports the type of rotary encoder that has a phase change on both input signals when rotating one `notch`.
 
-# How it works
+The article on my web site explains the software mechanisms used in detail so you can understand
+the coding and might be able to adjust it to your needs if you like:
 
-The best way to see how it works is to install the library and have a look at the examples. They are quite stright forward.
-The fork library is retro-compatible with the original RotaryEncoder library.
+<http://www.mathertel.de/Arduino/RotaryEncoderLibrary.aspx>
+
+There are various aspects when writing a library for rotary encoders and you can also find a lot of the sources I analysed at the bottom of this article.
+
+
+## updates
+
+* 26.01.2020 Added debounce functionality for the encoder's push button. Based on the Bounce library by Thomas Fredericks' Bounce library: https://playground.arduino.cc/Code/Bounce/

--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
-# RotaryEncoder library
+# BounceRotaryEncoder library
 
-A library for the Arduino environment for using a rotary encoder as an input.
+This is a fork of the RotaryEncoder library by @mathertel which includes the debouncing functionallity for the push button.
+The debounce functionallity is based on the original Bounce library by Thomas Frederick.
 
-Here you can find an Arduino compatible library for using rotary encoders.
+* Original RotaryEncoder library: https://github.com/mathertel/RotaryEncoder
+* Original Bounce library: https://playground.arduino.cc/Code/Bounce/
 
-I was searching a library for using a rotary encoder in my latest project and found a lot of information on this topic but none of the existing libraries did immediately match my expectations so I finally built my own.
+# Why?
 
-It supports the type of rotary encoder that has a phase change on both input signals when rotating one `notch`.
+If you are working on a project with multiple push buttons, it makes sense to use any other library to manage the debouncing of said buttons. However if you are working on a small project in which you only need the push button of the encoder, you can use this library to manage that.
 
-The article on my web site explains the software mechanisms used in detail so you can understand
-the coding and might be able to adjust it to your needs if you like:
+# How it works
 
-<http://www.mathertel.de/Arduino/RotaryEncoderLibrary.aspx>
-
-There are various aspects when writing a library for rotary encoders and you can also find a lot of the sources I analysed at the bottom of this article.
-
-
-## updates
-
-* 26.01.2020 Added debounce functionality for the encoder's push button. Based on the Bounce library by Thomas Fredericks' Bounce library: https://playground.arduino.cc/Code/Bounce/
+The best way to see how it works is to install the library and have a look at the examples. They are quite stright forward.
+The fork library is retro-compatible with the original RotaryEncoder library.

--- a/RotaryEncoder.cpp
+++ b/RotaryEncoder.cpp
@@ -8,9 +8,15 @@
 // 18.01.2014 created by Matthias Hertel
 // 17.06.2015 minor updates.
 // -----
+// 26.01.2020 Added Debounce functionality for the pus button. Based upon the Bounce library by Thomas Frederics https://playground.arduino.cc/Code/Bounce/
 
 #include "Arduino.h"
 #include "RotaryEncoder.h"
+
+//New
+
+
+//new
 
 
 // The array holds the values �1 for the entries where a position was decremented,
@@ -32,12 +38,12 @@ const int8_t KNOBDIR[] = {
 
 // ----- Initialization and Default Values -----
 
-RotaryEncoder::RotaryEncoder(int pin1, int pin2) {
-  
+RotaryEncoder::RotaryEncoder(int pin1, int pin2, uint8_t buttonPin, unsigned long interval_millis) {
+
   // Remember Hardware Setup
   _pin1 = pin1;
   _pin2 = pin2;
-  
+
   // Setup the input pins and turn on pullup resistor
   pinMode(pin1, INPUT_PULLUP);
   pinMode(pin2, INPUT_PULLUP);
@@ -49,8 +55,42 @@ RotaryEncoder::RotaryEncoder(int pin1, int pin2) {
   _position = 0;
   _positionExt = 0;
   _positionExtPrev = 0;
+
+// Push Button debounce
+
+  pinMode(buttonPin, INPUT_PULLUP);
+  interval(interval_millis);
+  previous_millis = millis();
+  state = digitalRead(buttonPin);
+    this->buttonPin = buttonPin;
+
+// End Push Button debounce
+
+
+
 } // RotaryEncoder()
 
+RotaryEncoder::RotaryEncoder(int pin1, int pin2) {
+
+  // Remember Hardware Setup
+  _pin1 = pin1;
+  _pin2 = pin2;
+  //_buttonPin = buttonPin;
+
+  // Setup the input pins and turn on pullup resistor
+  pinMode(pin1, INPUT_PULLUP);
+  pinMode(pin2, INPUT_PULLUP);
+    // NEW ++++++++++++
+
+  // when not started in motion, the current state of the encoder should be 3
+  _oldState = 3;
+
+  // start with position 0;
+  _position = 0;
+  _positionExt = 0;
+  _positionExtPrev = 0;
+
+} // RotaryEncoder()
 
 long  RotaryEncoder::getPosition() {
   return _positionExt;
@@ -60,7 +100,7 @@ long  RotaryEncoder::getPosition() {
 RotaryEncoder::Direction RotaryEncoder::getDirection() {
 
     RotaryEncoder::Direction ret = Direction::NOROTATION;
-    
+
     if( _positionExtPrev > _positionExt )
     {
         ret = Direction::COUNTERCLOCKWISE;
@@ -71,12 +111,12 @@ RotaryEncoder::Direction RotaryEncoder::getDirection() {
         ret = Direction::CLOCKWISE;
         _positionExtPrev = _positionExt;
     }
-    else 
+    else
     {
         ret = Direction::NOROTATION;
         _positionExtPrev = _positionExt;
-    }        
-    
+    }
+
     return ret;
 }
 
@@ -98,21 +138,93 @@ void RotaryEncoder::tick(void)
 
   if (_oldState != thisState) {
     _position += KNOBDIR[thisState | (_oldState<<2)];
-    
+
     if (thisState == LATCHSTATE) {
       _positionExt = _position >> 2;
       _positionExtTimePrev = _positionExtTime;
       _positionExtTime = millis();
     }
-    
+
     _oldState = thisState;
   } // if
 } // tick()
 
 unsigned long RotaryEncoder::getMillisBetweenRotations() const
 {
-  return _positionExtTime - _positionExtTimePrev; 
+  return _positionExtTime - _positionExtTimePrev;
 }
 
+
+// Push Button debounce
+
+void RotaryEncoder::write(int new_state)
+       {
+         this->state = new_state;
+        digitalWrite(buttonPin,state);
+       }
+
+
+void RotaryEncoder::interval(unsigned long interval_millis)
+{
+  this->interval_millis = interval_millis;
+  this->rebounce_millis = 0;
+}
+
+void RotaryEncoder::rebounce(unsigned long interval)
+{
+   this->rebounce_millis = interval;
+}
+
+
+
+int RotaryEncoder::update()
+{
+  if ( debounce() ) {
+        rebounce(0);
+        return stateChanged = 1;
+    }
+
+     // We need to rebounce, so simulate a state change
+
+  if ( rebounce_millis && (millis() - previous_millis >= rebounce_millis) ) {
+        previous_millis = millis();
+     rebounce(0);
+     return stateChanged = 1;
+  }
+
+  return stateChanged = 0;
+}
+
+
+unsigned long RotaryEncoder::duration()
+{
+  return millis() - previous_millis;
+}
+
+
+int RotaryEncoder::read()
+{
+  return (int)state;
+}
+
+
+// Protected: debounces the pin
+int RotaryEncoder::debounce() {
+
+  uint8_t newState = digitalRead(buttonPin);
+  if (state != newState ) {
+      if (millis() - previous_millis >= interval_millis) {
+        previous_millis = millis();
+        state = newState;
+        return 1;
+  }
+  }
+
+  return 0;
+
+}
+
+
+// End Push Button debounce
 
 // End

--- a/RotaryEncoder.h
+++ b/RotaryEncoder.h
@@ -8,6 +8,7 @@
 // 18.01.2014 created by Matthias Hertel
 // 16.06.2019 pin initialization using INPUT_PULLUP
 // -----
+// 26.01.2020 Added Debounce functionality for the pus button. Based upon the Bounce library by Thomas Frederics https://playground.arduino.cc/Code/Bounce/
 
 #ifndef RotaryEncoder_h
 #define RotaryEncoder_h
@@ -16,17 +17,21 @@
 
 #define LATCHSTATE 3
 
+#include <inttypes.h>
+
+
 class RotaryEncoder
 {
 public:
   enum class Direction { NOROTATION = 0, CLOCKWISE = 1, COUNTERCLOCKWISE = -1};
 
   // ----- Constructor -----
-  RotaryEncoder(int pin1, int pin2);
-  
+  RotaryEncoder(int pin1, int pin2, uint8_t buttonPin, unsigned long interval_millis); //Constructor with push button debounce
+  RotaryEncoder(int pin1, int pin2);  //Legacy constructor
+
   // retrieve the current position
   long  getPosition();
-  
+
   // simple retrieve of the direction the knob was rotated at. 0 = No rotation, 1 = Clockwise, -1 = Counter Clockwise
   Direction getDirection();
 
@@ -36,20 +41,56 @@ public:
   // call this function every some milliseconds or by using an interrupt for handling state changes of the rotary encoder.
   void tick(void);
 
-  // Returns the time in milliseconds between the current observed 
+  // Returns the time in milliseconds between the current observed
   unsigned long getMillisBetweenRotations() const;
 
+
+//  Push Button debounce
+
+
+  void interval(unsigned long interval_millis);
+  // Updates the pin
+  // Returns 1 if the state changed
+  // Returns 0 if the state did not change
+  int update();
+  // Forces the pin to signal a change (through update()) in X milliseconds
+  // even if the state does not actually change
+  // Example: press and hold a button and have it repeat every X milliseconds
+  void rebounce(unsigned long interval);
+  // Returns the updated pin state
+  int read();
+  // Sets the stored pin state
+  void write(int new_state);
+    // Returns the number of milliseconds the pin has been in the current state
+  unsigned long duration();
+
+
+//   End Push Button debounce
+
+
+
 private:
-  int _pin1, _pin2; // Arduino pins used for the encoder. 
-  
+  int _pin1, _pin2; // Arduino pins used for the encoder.
+
   volatile int8_t _oldState;
-  
+
   volatile long _position;         // Internal position (4 times _positionExt)
   volatile long _positionExt;      // External position
   volatile long _positionExtPrev;  // External position (used only for direction checking)
 
   unsigned long _positionExtTime;     // The time the last position change was detected.
   unsigned long _positionExtTimePrev; // The time the previous position change was detected.
+
+// Push Button debounce
+
+  int debounce();
+  unsigned long  previous_millis, interval_millis, rebounce_millis;
+  uint8_t state;
+  uint8_t buttonPin;
+  uint8_t stateChanged;
+
+// End Push Button debounce
+
 };
 
 #endif

--- a/examples/Push_Button/Push_Button.ino
+++ b/examples/Push_Button/Push_Button.ino
@@ -1,0 +1,76 @@
+#include <RotaryEncoder.h>
+
+#define ROTARYSTEPS 1
+#define ROTARYMIN -1
+#define ROTARYMAX 36
+#define START_POSITION 0
+
+#define ENCODER_CW 6
+#define ENCODER_CCW 5
+
+#define ROTARY_BUTTON 8
+
+
+
+// Setup a RoraryEncoder
+
+RotaryEncoder encoder(ENCODER_CW, ENCODER_CCW, ROTARY_BUTTON, 10);  // with push button...
+//RotaryEncoder encoder(ENCODER_CW, ENCODER_CCW);                   // ...or without
+
+
+// Last known rotary position.
+int lastPos = -1;
+
+void setup() {
+
+  Serial.begin(9600);
+
+  encoder.setPosition(START_POSITION / ROTARYSTEPS);
+
+}
+
+
+void loop() {
+
+
+  encoder.tick();
+
+  // get the current physical position and calc the logical position
+  int newPos = encoder.getPosition() * ROTARYSTEPS;
+
+  if (newPos < ROTARYMIN) {
+    encoder.setPosition(ROTARYMIN / ROTARYSTEPS);
+    newPos = ROTARYMIN;
+
+  } else if (newPos > ROTARYMAX) {
+    encoder.setPosition(ROTARYMAX / ROTARYSTEPS);
+    newPos = ROTARYMAX;
+
+  }
+
+
+  if (lastPos != newPos) {
+
+    if (newPos>lastPos){
+
+    Serial.println("Encoder rotated one position in one direction");
+
+      }else{
+
+    Serial.println("Encoder rotated one position in the other direction");
+        }
+
+    Serial.print(newPos);
+    Serial.println();
+    lastPos = newPos;
+
+
+  }
+
+  if (encoder.update() && encoder.read()==LOW){   // If push button is pressed...
+
+  Serial.println("button pushed");
+
+  }
+
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,13 @@
+RotaryEncoder	KEYWORD1
+
+getPosition	KEYWORD2
+getDirection	KEYWORD2
+setPosition	KEYWORD2
+tick		KEYWORD2
+getMillisBetweenRotations	KEYWORD2
+interval	KEYWORD2
+update		KEYWORD2
+rebounce	KEYWORD2
+read		KEYWORD2
+write		KEYWORD2
+duration	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 name=BounceRotaryEncoder
 version=1.0.0
 author=Felix Hauser
@@ -13,14 +12,3 @@ paragraph=This library facilitates the use of a rotary encoder as as well as deb
 url=https://github.com/FelixHauser
 >>>>>>> parent of 8b4315f... Update library.properties
 architectures=*
-=======
-name=RotaryEncoder
-version=1.3.0
-author=Matthias Hertel
-maintainer=Matthias Hertel, http://www.mathertel.de
-sentence=Use a rotary encoder with quadrature pulses as an input device.
-paragraph=This library decodes the signals from a rotary encoder and translates them into a counter position. The library comes with some samples that show how to use the library with and without interrupts.
-category=Signal Input/Output
-url=http://www.mathertel.de/Arduino/RotaryEncoderLibrary.aspx
-architectures=*
->>>>>>> parent of 6ba22ea... Update library.properties

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,8 @@
-name=RotaryEncoder
-version=1.3.0
-author=Matthias Hertel
-maintainer=Matthias Hertel, http://www.mathertel.de
-sentence=Use a rotary encoder with quadrature pulses as an input device.
-paragraph=This library decodes the signals from a rotary encoder and translates them into a counter position. The library comes with some samples that show how to use the library with and without interrupts.
-category=Signal Input/Output
-url=http://www.mathertel.de/Arduino/RotaryEncoderLibrary.aspx
+name=BounceRotaryEncoder
+version=1.0.0
+author=Felix Hauser
+maintainer=Felix Hauser, https://github.com/FelixHauser
+sentence=Use a rotary encoder as well as the push button.
+paragraph=This library facilitates the use of a rotary encoder as as well as debouncing the signmal for the push button. Intended for small projects with an encoder as a single input device.
+url=https://github.com/FelixHauser
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,6 @@ version=1.0.0
 author=Felix Hauser
 maintainer=Felix Hauser, https://github.com/FelixHauser
 sentence=Use a rotary encoder as well as the push button.
-paragraph=This library facilitates the use of a rotary encoder as as well as debouncing the signmal for the push button. Intended for small projects with an encoder as a single input device.
+paragraph=This library facilitates the use of a rotary encoder as as well as debouncing the signal for the push button. Intended for small projects with an encoder as a single input device.
 url=https://github.com/FelixHauser
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 name=BounceRotaryEncoder
 version=1.0.0
 author=Felix Hauser
@@ -12,3 +13,14 @@ paragraph=This library facilitates the use of a rotary encoder as as well as deb
 url=https://github.com/FelixHauser
 >>>>>>> parent of 8b4315f... Update library.properties
 architectures=*
+=======
+name=RotaryEncoder
+version=1.3.0
+author=Matthias Hertel
+maintainer=Matthias Hertel, http://www.mathertel.de
+sentence=Use a rotary encoder with quadrature pulses as an input device.
+paragraph=This library decodes the signals from a rotary encoder and translates them into a counter position. The library comes with some samples that show how to use the library with and without interrupts.
+category=Signal Input/Output
+url=http://www.mathertel.de/Arduino/RotaryEncoderLibrary.aspx
+architectures=*
+>>>>>>> parent of 6ba22ea... Update library.properties

--- a/library.properties
+++ b/library.properties
@@ -3,7 +3,12 @@ version=1.0.0
 author=Felix Hauser
 maintainer=Felix Hauser, https://github.com/FelixHauser
 sentence=Use a rotary encoder as well as the push button.
+<<<<<<< HEAD
 paragraph=This library facilitates the use of a rotary encoder as as well as debouncing the signal for the push button. Intended for small projects with an encoder as a single input device.
 caterogy=Signal Input/Output
 url=https://github.com/FelixHauser/BounceRotaryEncoder
+=======
+paragraph=This library facilitates the use of a rotary encoder as as well as debouncing the signmal for the push button. Intended for small projects with an encoder as a single input device.
+url=https://github.com/FelixHauser
+>>>>>>> parent of 8b4315f... Update library.properties
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -3,12 +3,7 @@ version=1.0.0
 author=Felix Hauser
 maintainer=Felix Hauser, https://github.com/FelixHauser
 sentence=Use a rotary encoder as well as the push button.
-<<<<<<< HEAD
 paragraph=This library facilitates the use of a rotary encoder as as well as debouncing the signal for the push button. Intended for small projects with an encoder as a single input device.
 caterogy=Signal Input/Output
 url=https://github.com/FelixHauser/BounceRotaryEncoder
-=======
-paragraph=This library facilitates the use of a rotary encoder as as well as debouncing the signmal for the push button. Intended for small projects with an encoder as a single input device.
-url=https://github.com/FelixHauser
->>>>>>> parent of 8b4315f... Update library.properties
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Felix Hauser
 maintainer=Felix Hauser, https://github.com/FelixHauser
 sentence=Use a rotary encoder as well as the push button.
 paragraph=This library facilitates the use of a rotary encoder as as well as debouncing the signal for the push button. Intended for small projects with an encoder as a single input device.
-url=https://github.com/FelixHauser
+caterogy=Signal Input/Output
+url=https://github.com/FelixHauser/BounceRotaryEncoder
 architectures=*


### PR DESCRIPTION
I added a debounce functionality for the Rotary Encoder's push button so that no other library is needed. 
The debounce code is adapted from Thomas Frederick's Bounce library (see readme.md).
I overloaded the original constructor to accommodate for pin number of the push button as well as the time (in ms) for the debouncing. The original constructor works as per usual, so users updating the library won't have to modify their codes.
An example of the use is also added.

Regards,
FH
