### PR TITLE
Added "A" to each example

### DIFF
--- a/examples/AcceleratedRotator/AcceleratedRotator.ino
+++ b/examples/AcceleratedRotator/AcceleratedRotator.ino
@@ -28,8 +28,8 @@
 
 #if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO_EVERY)
 // Example for Arduino UNO with input signals on pin 2 and 3
-#define PIN_IN1 2
-#define PIN_IN2 3
+#define PIN_IN1 A2
+#define PIN_IN2 A3
 
 #elif defined(ESP8266)
 // Example for ESP8266 NodeMCU with input signals on pin D5 and D6

--- a/examples/InterruptRotator/InterruptRotator.ino
+++ b/examples/InterruptRotator/InterruptRotator.ino
@@ -30,8 +30,8 @@
 
 #if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO_EVERY)
 // Example for Arduino UNO with input signals on pin 2 and 3
-#define PIN_IN1 2
-#define PIN_IN2 3
+#define PIN_IN1 A2
+#define PIN_IN2 A3
 
 #elif defined(ESP8266)
 // Example for ESP8266 NodeMCU with input signals on pin D5 and D6

--- a/examples/LimitedRotator/LimitedRotator.ino
+++ b/examples/LimitedRotator/LimitedRotator.ino
@@ -26,8 +26,8 @@
 
 #if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO_EVERY)
 // Example for Arduino UNO with input signals on pin 2 and 3
-#define PIN_IN1 2
-#define PIN_IN2 3
+#define PIN_IN1 A2
+#define PIN_IN2 A3
 
 #elif defined(ESP8266)
 // Example for ESP8266 NodeMCU with input signals on pin D5 and D6

--- a/examples/SimplePollRotator/SimplePollRotator.ino
+++ b/examples/SimplePollRotator/SimplePollRotator.ino
@@ -25,8 +25,8 @@
 
 #if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO_EVERY)
 // Example for Arduino UNO with input signals on pin 2 and 3
-#define PIN_IN1 2
-#define PIN_IN2 3
+#define PIN_IN1 A2
+#define PIN_IN2 A3
 
 #elif defined(ESP8266)
 // Example for ESP8266 NodeMCU with input signals on pin D5 and D6

--- a/examples/SimplePollRotatorLCD/SimplePollRotatorLCD.ino
+++ b/examples/SimplePollRotatorLCD/SimplePollRotatorLCD.ino
@@ -22,8 +22,8 @@
 
 #if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO_EVERY)
 // Example for Arduino UNO with input signals on pin 2 and 3
-#define PIN_IN1 2
-#define PIN_IN2 3
+#define PIN_IN1 A2
+#define PIN_IN2 A3
 
 #elif defined(ESP8266)
 // Example for ESP8266 NodeMCU with input signals on pin D5 and D6


### PR DESCRIPTION
The "A" was missing from both Analog definitions on each example.