### PR TITLE
added setPositionLimits to handle limited rotators

### DIFF
--- a/examples/LimitedRotator/LimitedRotator.ino
+++ b/examples/LimitedRotator/LimitedRotator.ino
@@ -55,6 +55,7 @@ void setup()
   while (! Serial);
   Serial.println("LimitedRotator example for the RotaryEncoder library.");
   encoder.setPosition(10 / ROTARYSTEPS); // start with the value of 10.
+  encoder.setPositionLimits( ROTARYMIN / ROTARYSTEPS, ROTARYMAX / ROTARYSTEPS );
 } // setup()
 
 
@@ -65,15 +66,6 @@ void loop()
 
   // get the current physical position and calc the logical position
   int newPos = encoder.getPosition() * ROTARYSTEPS;
-
-  if (newPos < ROTARYMIN) {
-    encoder.setPosition(ROTARYMIN / ROTARYSTEPS);
-    newPos = ROTARYMIN;
-
-  } else if (newPos > ROTARYMAX) {
-    encoder.setPosition(ROTARYMAX / ROTARYSTEPS);
-    newPos = ROTARYMAX;
-  } // if
 
   if (lastPos != newPos) {
     Serial.print(newPos);

--- a/src/RotaryEncoder.cpp
+++ b/src/RotaryEncoder.cpp
@@ -14,6 +14,7 @@
 
 #include "RotaryEncoder.h"
 #include "Arduino.h"
+#include <limits.h>
 
 #define LATCH0 0 // input state at position 0
 #define LATCH3 3 // input state at position 3
@@ -58,6 +59,10 @@ RotaryEncoder::RotaryEncoder(int pin1, int pin2, LatchMode mode)
   _position = 0;
   _positionExt = 0;
   _positionExtPrev = 0;
+
+  // set absolute min max limits of our storage type
+  _positionMin = LONG_MIN;
+  _positionMax = LONG_MAX;
 } // RotaryEncoder()
 
 
@@ -146,7 +151,15 @@ void RotaryEncoder::tick(void)
       }
       break;
     } // switch
+
+	 // apply limits
+    if (_positionExt < _positionMin) {
+      setPosition(_positionMin);
+    } else if (_positionExt > _positionMax) {
+      setPosition(_positionMax);
+    } // if
   } // if
+
 } // tick()
 
 
@@ -164,5 +177,22 @@ unsigned long RotaryEncoder::getRPM()
   return 60000.0 / ((float)(t * 20));
 }
 
+void RotaryEncoder::setPositionLimits(long min, long max)
+{
+  if (max < min) {
+    long temp = min;
+    min = max;
+    max = temp;
+  }
+
+  _positionMin = min;
+  _positionMax = max;
+
+  if (_positionExt < _positionMin) {
+    setPosition(_positionMin);
+  } else if (_positionExt > _positionMax) {
+    setPosition(_positionMax);
+  } // if
+} // setPositionLimits()
 
 // End

--- a/src/RotaryEncoder.h
+++ b/src/RotaryEncoder.h
@@ -56,9 +56,12 @@ public:
   // Returns the RPM
   unsigned long getRPM();
 
+  // Set min and max value of position
+  void setPositionLimits(long min, long max);
+
 private:
   int _pin1, _pin2; // Arduino pins used for the encoder.
-  
+
   LatchMode _mode; // Latch mode from initialization
 
   volatile int8_t _oldState;
@@ -69,6 +72,9 @@ private:
 
   unsigned long _positionExtTime;     // The time the last position change was detected.
   unsigned long _positionExtTimePrev; // The time the previous position change was detected.
+
+  long _positionMin;
+  long _positionMax;
 };
 
 #endif


### PR DESCRIPTION
Its better to have the library handle the limits. This implementation always stores a min and max value that are initialized to LONG_MIN and LONG_MAX to handle the limitless case, the extra few compare operations in tick() and negligible and does not impact the performance. (performance sensitive cases would anyway use interrupts)